### PR TITLE
Support no_proxy

### DIFF
--- a/t/001_api.t
+++ b/t/001_api.t
@@ -7,7 +7,7 @@ use Test::More tests => 2;
 use HTTP::Tiny;
 
 my @accessors = qw(
-  agent default_headers local_address max_redirect max_size proxy timeout SSL_options verify_SSL cookie_jar
+  agent default_headers local_address max_redirect max_size proxy no_proxy timeout SSL_options verify_SSL cookie_jar
 );
 my @methods   = qw(
   new get head put post delete post_form request mirror www_form_urlencode

--- a/t/141_no_proxy.t
+++ b/t/141_no_proxy.t
@@ -1,0 +1,37 @@
+#!perl
+use strict;
+use warnings;
+
+use File::Basename;
+use Test::More 0.88;
+
+use HTTP::Tiny;
+
+for my $proxy ([], ["localhost"]){
+    local $ENV{no_proxy} = $proxy;
+    my $c = HTTP::Tiny->new();
+    ok(defined $c->no_proxy);
+}
+
+{
+    local $ENV{no_proxy} = "localhost,example.com";
+    my $c = HTTP::Tiny->new();
+    is_deeply($c->no_proxy, ["localhost", "example.com"]);
+}
+
+{
+    local $ENV{no_proxy} = "localhost,example.com";
+    my $c = HTTP::Tiny->new();
+    ok($c->_match_no_proxy('localhost'));
+    ok($c->_match_no_proxy('example.com'));
+    ok(!$c->_match_no_proxy('perl.org'));
+}
+
+{
+    eval {
+        my $c = HTTP::Tiny->new(no_proxy => 'localhost');
+    };
+    like($@, qr{should be ArrayRef});
+}
+
+done_testing();


### PR DESCRIPTION
HTTP::Tiny uses proxy if user sets `http_proxy` environment value.
But user wants not use proxy for some hosts, such as localhost, hosts in LAN.
In such case, some applications(eg. curl, wget) use `no_proxy` or `NO_PROXY` environment value.
I implemented it to HTTP::Tiny. If user sets `no_proxy` environment value, it is comma-separated
list of hosts, HTTP::Tiny does not use proxy for these hosts. User can also set hosts not used proxy
by constructor.

Please review this patch.
