### PR TITLE
allow @ in username in basic auth from URL

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -576,7 +576,7 @@ sub _split_url {
     my ($auth,$host);
     $authority = (length($authority)) ? $authority : 'localhost';
     if ( $authority =~ /@/ ) {
-        ($auth,$host) = $authority =~ m/\A([^@]*)@(.*)\z/;   # user:pass@host
+        ($auth,$host) = $authority =~ m/\A(.*)@(.*)\z/;   # user:pass@host
     }
     else {
         $host = $authority;


### PR DESCRIPTION
Some services (Feedbin, I'm looking at you) want basic auth using
your email address as the user part.  This doesn't work if we stop
looking for credentials at the first @.  Given:

  https://rjbs@cpan.org:password@someservice.com/

We want: rjbs@cpan.org, password, someservice.com

And not: rjbs, undef, cpan.org:password@someservice.com
