### PR TITLE
Do not overwrite original Host header if was provided

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -466,7 +466,7 @@ sub _prepare_headers_and_cb {
             $request->{headers}{lc $k} = $v;
         }
     }
-    $request->{headers}{'host'}         = $request->{host_port};
+    $request->{headers}{'host'}       ||= $request->{host_port};
     $request->{headers}{'connection'}   = "close";
     $request->{headers}{'user-agent'} ||= $self->{agent};
 


### PR DESCRIPTION
It is unfortunate, that HTTP::Tiny overwrites Host header. Usually it is the same as host:port, but in some cases there is a need to set the Host header to something different.

Please allow to change this header.
