### PR TITLE
Avoid multiple writes when sending request

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -1110,7 +1110,7 @@ sub write_header_lines {
     (@_ == 2 || @_ == 3 && ref $_[1] eq 'HASH') || die(q/Usage: $handle->write_header_lines(headers[,prefix])/ . "\n");
     my($self, $headers, $prefix_data) = @_;
 
-    my $buf = ($prefix_data ? $prefix_data : '');
+    my $buf = (defined $prefix_data ? $prefix_data : '');
     while (my ($k, $v) = each %$headers) {
         my $field_name = lc $k;
         if (exists $HeaderCase{$field_name}) {


### PR DESCRIPTION
This change doesn't make any real difference to HTTP::Tiny unless you use keep_alive=1. If you do use keep_alive = 1, then because the socket is kept open when write_request_header() issues 2 small writes it is subject to the nagle algorithm. A simple benchmark GETting 2000 small files can increase from 5s to 79s.

An alternative is to set TCP_NODELAY but this might have other implications so combining the writes is the easiest and probably best solution.

See http://www.martin-evans.me.uk/node/169 for discussion of how I came across this.
