### PR TITLE
Ensure tests pass with a SOCKS proxy configured

### DIFF
--- a/t/140_proxy.t
+++ b/t/140_proxy.t
@@ -10,6 +10,8 @@ use HTTP::Tiny;
 
 # Require a true value
 for my $proxy (undef, "", 0){
+    local $ENV{all_proxy} = undef;
+    local $ENV{ALL_PROXY} = undef;
     local $ENV{http_proxy} = $proxy;
     my $c = HTTP::Tiny->new();
     ok(!defined $c->http_proxy);


### PR DESCRIPTION
HTTP::Tiny uses "ALL_PROXY" and "all_proxy" from the environment to
configure which proxy it uses.  This change makes tests pass on a system
with these values set.

HTTP::Tiny throws an exception if it has a value of 0 or the empty
string for these environment variables, so always set them to the
undefined value.
