### PR TITLE
HTTPS CONNECT command requires host:port for proxy compatibility

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -483,6 +483,7 @@ sub _request {
         method    => $method,
         scheme    => $scheme,
         host      => $host,
+        port      => $port,
         host_port => ($port == $DefaultPort{$scheme} ? $host : "$host:$port"),
         uri       => $path_query,
         headers   => {},
@@ -619,9 +620,9 @@ sub _create_proxy_tunnel {
 
     my $connect_request = {
         method    => 'CONNECT',
-        uri       => $request->{host_port},
+        uri       => "$request->{host}:$request->{port}",
         headers   => {
-            host => $request->{host_port},
+            host => "$request->{host}:$request->{port}",
             'user-agent' => $agent,
         }
     };


### PR DESCRIPTION
This commit alters the CONNECT command to include the port in the URI and headers to allow proxy tools such as Charles and Fiddler2 (and others) to successfully direct the CONNECT command. Without this, the CONNECT command is attempted as HTTP and fails.
