### PR TITLE
perlcritic: enable ProhibitStringyEval

### DIFF
--- a/perlcritic.rc
+++ b/perlcritic.rc
@@ -11,7 +11,6 @@ allow = refs
 variables = $DB::single
 
 # Turn these off
-[-BuiltinFunctions::ProhibitStringyEval]
 [-ControlStructures::ProhibitPostfixControls]
 [-ControlStructures::ProhibitUnlessBlocks]
 [-Documentation::RequirePodSections]
@@ -22,5 +21,4 @@ variables = $DB::single
 [-Modules::ProhibitEvilModules]
 
 # Turn this on
-[Lax::ProhibitStringyEval::ExceptForRequire]
-
+[BuiltinFunctions::ProhibitStringyEval]


### PR DESCRIPTION
- stringy eval are not used in the current code
- stringy eval is bad even for require