### PR TITLE
Add Lax::ProhibitStringyEval::ExceptForRequire as develop dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -29,3 +29,7 @@ Net::SSLeay = 1.49
 
 [Prereqs / Suggests]
 IO::Socket::SSL = 1.56
+
+[Prereqs / DevelopRequires]
+; Non core Perl::Critic policy used in perlcritic.rc
+Perl::Critic::Policy::Lax::ProhibitStringyEval::ExceptForRequire = 0


### PR DESCRIPTION
As #64 has been rejected, we have to fix the develop dependencies to add that non-core Perl::Critic::Policy. The point is to have all Perl::Critic policies listed in `dzil listdeps --author --missing`.

Here is the commit:
> Lax::ProhibitStringyEval::ExceptForRequire is listed in perlcritic.rc but it isn't a core Perl::Critic policy. If it is not installed, a warning is triggered by the Test::Perl::Critic author test.
> DZP::Test::Perl::Critic doesn't yet parse perlcritic.rc to inject the missing policiy (I plan to fix that), so for now, just add the dependency manually.