### PR TITLE
Implement can_ssl(). Fix #67

### DIFF
--- a/t/001_api.t
+++ b/t/001_api.t
@@ -11,7 +11,7 @@ my @accessors = qw(
   max_redirect max_size proxy no_proxy timeout SSL_options verify_SSL cookie_jar
 );
 my @methods   = qw(
-  new get head put post delete post_form request mirror www_form_urlencode
+  new get head put post delete post_form request mirror www_form_urlencode can_ssl
 );
 
 my %api;


### PR DESCRIPTION
This implements can_ssl() method that is a public version of _assert_ssl in HTTP::Tiny::Handle, so that wrapper modules and callers can determine if an HTTPS request can be made, instead of running one and getting a runtime exception.