### PR TITLE
Deal with stat and daylight savings issues on Windows

### DIFF
--- a/t/110_mirror.t
+++ b/t/110_mirror.t
@@ -51,6 +51,11 @@ for my $file ( dir_list("corpus", qr/^mirror/ ) ) {
     open my $fh, ">", $tempfile;
     close $fh;
     utime $mtime, $mtime, $tempfile;
+    if ($^O eq 'MSWin32') {
+        # Deal with stat and daylight savings issues on Windows
+        # by reading back mtime
+        $timestamp{$url_basename} = (stat $tempfile)[9];
+    }
   }
 
   # setup mocking and test


### PR DESCRIPTION
by reading back mtime after utime. This is due to a difference
in the way the underlying system calls on Windows behave.

Even though NTFS stores file times in UTC, what you get depends on
whether you ask for that information through a handle or filename.

See http://www.nu42.com/2015/03/stat-vs-fstat-msvcrt-windows.html