### PR TITLE
Update Mozilla::CA recommendation version to 20150826

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Release notes for HTTP-Tiny
 
 {{$NEXT}}
 
+    [CHANGED]
+
+    - Updated Mozilla::CA module recommendation version to 20150826
+
 0.056     2015-05-19 06:00:40-04:00 America/New_York
 
     - No changes from 0.055

--- a/dist.ini
+++ b/dist.ini
@@ -24,7 +24,7 @@ remove = threads
 HTTP::CookieJar = 0.001
 IO::Socket::IP = 0.25
 IO::Socket::SSL = 1.42
-Mozilla::CA = 20130114
+Mozilla::CA = 20150826
 Net::SSLeay = 1.49
 
 [Prereqs / Suggests]


### PR DESCRIPTION
Mozilla::CA has just been released with news certificates data from Mozilla.

Mozilla change log:
https://hg.mozilla.org/projects/nss/log/tip/lib/ckfw/builtins/certdata.txt