### PR TITLE
Add support for connecting to a particular IP.

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -151,9 +151,10 @@ sub sort_headers {
         *HTTP::Tiny::Handle::can_read = sub {1};
         *HTTP::Tiny::Handle::can_write = sub {1};
         *HTTP::Tiny::Handle::connect = sub {
-            my ($self, $scheme, $host, $port) = @_;
+            my ($self, $scheme, $host, $port, $peer) = @_;
             $self->{host}   = $monkey_host = $host;
             $self->{port}   = $monkey_port = $port;
+            $self->{peer}   = $peer;
             $self->{scheme} = $scheme;
             $self->{fh} = shift @req_fh;
             $self->{pid} = $$;


### PR DESCRIPTION
I have a place where I'd like to use HTTP::Tiny, but I have external mirror code that determines which IP to use.  This commit introduces a `peer` argument that indicates a particular IP to use, defaulting to letting the socket code look it up as normal.  The Host header, however, remains that of the specified URL.

For the obvious reason, this change doesn't work with proxies and will be silently ignored there.