### PR TITLE
recommend IO::Socket::IP 0.32

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,7 +22,7 @@ remove = threads
 
 [Prereqs / Recommends]
 HTTP::CookieJar = 0.001
-IO::Socket::IP = 0.25
+IO::Socket::IP = 0.32
 IO::Socket::SSL = 1.42
 Mozilla::CA = 20130114
 Net::SSLeay = 1.49


### PR DESCRIPTION
As #52 relates to an IO::Socket::IP issue https://rt.cpan.org/Public/Bug/Display.html?id=92075 that was fixed since 0.32, I would suggest update version requirement of IO::Socket::IP from 0.25 to 0.32.