### PR TITLE
Fix timeout attribute

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -110,7 +110,7 @@ sub new {
 
     my $self = {
         max_redirect => 5,
-        timeout      => 60,
+        timeout      => $args{timeout} || 60,
         keep_alive   => 1,
         verify_SSL   => $args{verify_SSL} || $args{verify_ssl} || 0, # no verification by default
         no_proxy     => $ENV{no_proxy},

--- a/t/004_timeout.t
+++ b/t/004_timeout.t
@@ -1,0 +1,28 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+use HTTP::Tiny;
+
+# Just make sure timeout is handled correctly as a constructor param,
+# and that it works as expected as an "attribute".
+
+my $default = 60;
+
+{
+    my $ua = HTTP::Tiny->new();
+    is $ua->timeout, $default, 'default timeout is as expected';
+}
+
+{
+    my $ua = HTTP::Tiny->new(timeout => 10);
+    is $ua->timeout, 10, 'timeout is handled as a constructor param';
+}
+
+{
+    my $ua = HTTP::Tiny->new();
+    $ua->timeout(15);
+    is $ua->timeout, 15, 'timeout works as expected as a r/w attribute';
+}


### PR DESCRIPTION
Fix for #87.

571119ce removed timeout from the list of standard attributes and defined a custom accessor, but it didn't do anything to handle timeout as a constructor param. This just makes the simplest fix
and adds a simple test.