### PR TITLE
Try harder to clean up %ENV in 140_proxy.t.

### DIFF
--- a/t/140_proxy.t
+++ b/t/140_proxy.t
@@ -68,6 +68,10 @@ for my $var ( qw/http_proxy https_proxy all_proxy/ ) {
 
 # ignore HTTP_PROXY with REQUEST_METHOD
 {
+    # in case previous clean-up failed for some reason
+    delete local @ENV{'http_proxy', 'https_proxy', 'all_proxy',
+                      'HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY'};
+
     local $ENV{HTTP_PROXY} = "http://localhost:8080";
     local $ENV{REQUEST_METHOD} = 'GET';
     my $c = HTTP::Tiny->new();


### PR DESCRIPTION
While the localization earlier in the test *should* leave the
relevent %ENV entries in a good state for the final test, for
some reason this is not happening on VMS.  It may have something
to do with the fact that %ENV has all upper case keys but the
test has previously localized both upper and lower case versions.

In any case, even though it isn't this test's fault, the easiest
and safest way to get it passing is to just do another clean-up.