### PR TITLE
preserve HTTP method on 307/308 redirects

### DIFF
--- a/corpus/redirect-11.txt
+++ b/corpus/redirect-11.txt
@@ -1,0 +1,56 @@
+url
+  http://example.com/index.html
+method
+  POST
+headers
+  Content-Type: text/plain
+  Content-Length: 42
+content
+  abcdefghijklmnopqrstuvwxyz1234567890abcdef
+expected
+  abcdefghijklmnopqrstuvwxyz1234567890abcdef
+expected_url
+  http://example.com/index3.html
+----------
+POST /index.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+Content-Length: 42
+Content-Type: text/plain
+
+abcdefghijklmnopqrstuvwxyz1234567890abcdef
+
+----------
+HTTP/1.1 307 Temporary Redirect
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/html
+Content-Length: 172
+Location: http://example.com/index3.html
+
+<html>
+<head><title>307 Temporary Redirect</title></head>
+<body bgcolor="white">
+<center><h1>307 Temporary Redirect</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>
+
+----------
+POST /index3.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+Content-Length: 42
+Content-Type: text/plain
+
+abcdefghijklmnopqrstuvwxyz1234567890abcdef
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 42
+
+abcdefghijklmnopqrstuvwxyz1234567890abcdef
+

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -895,7 +895,7 @@ sub _maybe_redirect {
     my ($status, $method) = ($response->{status}, $request->{method});
     $args->{_redirects} ||= [];
 
-    if (($status eq '303' or ($status =~ /^30[1278]/ && $method =~ /^GET|HEAD$/))
+    if (($status =~ /^30[378]/ or ($status =~ /^30[12]/ && $method =~ /^GET|HEAD$/))
         and $headers->{location}
         and @{$args->{_redirects}} < $self->{max_redirect}
     ) {

--- a/t/130_redirect.t
+++ b/t/130_redirect.t
@@ -27,6 +27,11 @@ for my $file ( dir_list("corpus", qr/^redirect/ ) ) {
 
   my %options;
   $options{headers} = \%headers if %headers;
+
+  if ( $case->{content} ) {
+    $options{content} = $case->{content}[0];
+  }
+
   my $call_args = %options ? [$method, $url, \%options] : [$method, $url];
 
   my $version = HTTP::Tiny->VERSION || 0;


### PR DESCRIPTION
This patch makes HTTP::Tiny handle 307/308 redirects similar to other popular user-agents, preserving HTTP method and content.

While https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html states:

> If the 307 status code is received in response to a request other than GET or HEAD, the user agent MUST NOT automatically redirect the request unless it can be confirmed by the user, since this might change the conditions under which the request was issued.

most user-agents support this through a flag (curl --location, LWP::UserAgent's requests_redirectable(), and Mojo::UserAgent's max_redirects) on a per-request basis, giving that implicit "confirmation by the user".

One problem I see is that HTTP::Tiny follows redirects by default, and does not distinguish between 30[123] or 30[78]. This patch changes the behavior for 30[78] non-GET/HEAD requests, though it could be argued that the previous behavior was broken for non-GET/HEAD requests, which means that the impact of this change is likely low.