### PR TITLE
Don't reuse closed connections

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -659,6 +659,7 @@ sub _request {
     }
 
     if ( $self->{keep_alive}
+        && $self->connected
         && $known_message_length
         && $response->{protocol} eq 'HTTP/1.1'
         && ($response->{headers}{connection} || '') ne 'close'


### PR DESCRIPTION
Sometimes, a closed connection isn't detected by HTTP::Tiny. To
reproduce the bug, use [feersum](https://github.com/stash/Feersum) sources:
```shell
$ perl Makefile.PL && make
$ taskset -c 0 perl -I blib/lib -I blib/arch t/63*
```
HTTP::Tiny tries to reuse a closed connection _(it looks like Feersum closes keep-alive connection on heavy load. A separate issue is opened for this)_.

This little patch fixes the problem.
