### PR TITLE
No proxy for localhost

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -695,15 +695,22 @@ sub _open_handle {
         keep_alive      => $self->{keep_alive}
     );
 
-    if ($self->{_has_proxy}{$scheme} 
-        && ! grep { $host =~ /\Q$_\E$/ } @{$self->{no_proxy}}
-        && $host !~ /^(localhost|127\.)/
-    ) {
+    if ($self->_should_use_proxy($scheme, $host)) {
         return $self->_proxy_connect( $request, $handle );
     }
     else {
         return $handle->connect($scheme, $host, $port, $peer);
     }
+}
+
+# Given a scheme and hostname, determine whether we would use a proxy
+# to connect to it.
+sub _should_use_proxy {
+    my ($self, $scheme, $host) = @_;
+
+    return $self->{_has_proxy}{$scheme} 
+        && $host !~ /^(localhost|127\.)/
+        && ! grep { $host =~ /\Q$_\E$/ } @{$self->{no_proxy}};
 }
 
 sub _proxy_connect {

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -695,7 +695,10 @@ sub _open_handle {
         keep_alive      => $self->{keep_alive}
     );
 
-    if ($self->{_has_proxy}{$scheme} && ! grep { $host =~ /\Q$_\E$/ } @{$self->{no_proxy}}) {
+    if ($self->{_has_proxy}{$scheme} 
+        && ! grep { $host =~ /\Q$_\E$/ } @{$self->{no_proxy}}
+        && $host !~ /^(localhost|127\.)/
+    ) {
         return $self->_proxy_connect( $request, $handle );
     }
     else {

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -709,7 +709,7 @@ sub _should_use_proxy {
     my ($self, $scheme, $host) = @_;
 
     return $self->{_has_proxy}{$scheme} 
-        && $host !~ /^(localhost|127\.)/
+        && $host !~ /^(localhost|127\.|::1$)/
         && ! grep { $host =~ /\Q$_\E$/ } @{$self->{no_proxy}};
 }
 

--- a/t/140_proxy.t
+++ b/t/140_proxy.t
@@ -80,4 +80,23 @@ for my $var ( qw/http_proxy https_proxy all_proxy/ ) {
 
 }
 
+# Ignore proxy settings if we're connecting to localhost
+{
+    my $c = HTTP::Tiny->new(
+        proxy => 'http://localhost:8080',
+    );
+    ok(
+        $c->_should_use_proxy("http", "www.google.com"),
+        "Would use proxy for www.google.com",
+    );
+    ok(
+        !$c->_should_use_proxy("http", "localhost"),
+        "No proxy for localhost",
+    );
+    ok(
+        !$c->_should_use_proxy("https", "127.0.0.1"),
+        "No proxy for 127.0.0.1",
+    );
+}
+
 done_testing();

--- a/t/140_proxy.t
+++ b/t/140_proxy.t
@@ -97,6 +97,10 @@ for my $var ( qw/http_proxy https_proxy all_proxy/ ) {
         !$c->_should_use_proxy("https", "127.0.0.1"),
         "No proxy for 127.0.0.1",
     );
+    ok(
+        !$c->_should_use_proxy("http", "::1"),
+        "No proxy for  ::1",
+    );
 }
 
 done_testing();


### PR DESCRIPTION
Don't try to use a proxy to connect to localhost/127.0.0.1, because:

(a) Doing so causes confusion and unexpected failures - e.g. many failures in Dancer's test suite - anywhere we use Test::TCP and HTTP::Tiny to test the built-in server fails on smokers with proxy env vars set
(b) Doing so could potentially be the caller trying nasty tricks - it's unlikely that they ought to be trying to get the proxy to connect to itself on localhost. 

Is this enough?  Should it go further, and check if the hostname we're given resolves to a 127.x IP, or is that overkill?

Feedback welcome.