### PR TITLE
Add PATCH method

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -186,7 +186,7 @@ sub _set_proxies {
     return;
 }
 
-=method get|head|put|post|delete
+=method get|head|put|post|patch|delete
 
     $response = $http->get($url);
     $response = $http->get($url, \%options);
@@ -200,7 +200,7 @@ The C<success> field of the response will be true if the status code is 2XX.
 
 =cut
 
-for my $sub_name ( qw/get head put post delete/ ) {
+for my $sub_name ( qw/get head put post patch delete/ ) {
     my $req_method = uc $sub_name;
     no strict 'refs';
     eval <<"HERE"; ## no critic

--- a/t/001_api.t
+++ b/t/001_api.t
@@ -11,7 +11,7 @@ my @accessors = qw(
   max_redirect max_size proxy no_proxy timeout SSL_options verify_SSL cookie_jar
 );
 my @methods   = qw(
-  new get head put post delete post_form request mirror www_form_urlencode can_ssl
+  new get head put post patch delete post_form request mirror www_form_urlencode can_ssl
   connected
 );
 


### PR DESCRIPTION
Adds an additional PATCH method to the standard convenience set (get, head, put, post, delete).  PATCH is common for REST web services and was given official definition in RFC 5789 (https://tools.ietf.org/html/rfc5789)

Note that PATCH is not considered idempotent.