### PR TITLE
Updated HTTP::Tiny HTTP_PROXY handling to be the same as LWP::UserAgent

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -152,7 +152,7 @@ sub _set_proxies {
     # http proxy
     if (! exists $self->{http_proxy} ) {
         # under CGI, bypass HTTP_PROXY as request sets it from Proxy header
-        local $ENV{HTTP_PROXY} if $ENV{REQUEST_METHOD};
+        local $ENV{HTTP_PROXY} = $ENV{CGI_HTTP_PROXY} if $ENV{REQUEST_METHOD};
         $self->{http_proxy} = $ENV{http_proxy} || $ENV{HTTP_PROXY} || $self->{proxy};
     }
 


### PR DESCRIPTION
Due to Vulnerability Note VU#797896, the environment variable HTTP_PROXY may be tainted and cannot be use when in a CGI environment. 

In LWP::UserAgent the variable HTTP_PROXY is overridden by CGI_HTTP_PROXY.

This is a patch to support the same architecture in HTTP:Tiny.  Otherwise there is no easy way to proxy HTTP traffic under CGI differently than HTTPS traffic.  The current work around is to set ALL_PROXY but that impacts HTTPS traffic proxy capabilities.

