### PR TITLE
post_form - don't delete from incoming options hashref

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -245,7 +245,6 @@ sub post_form {
     while ( my ($key, $value) = each %{$args->{headers} || {}} ) {
         $headers->{lc $key} = $value;
     }
-    delete $args->{headers};
 
     return $self->request('POST', $url, {
             %$args,


### PR DESCRIPTION
Don't delete from the incoming options hashref, as the user may be using
it for other purposes.

Deleting the headers hash entry is not needed, as the hashref
constructed for the call to request will include its own headers entry
which will override the entry from the incoming options.