### PR TITLE
Fix incorrect env var name for verify_SSL default

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -149,7 +149,7 @@ sub _verify_SSL_default {
     my ($self) = @_;
     # Check if insecure default certificate verification behaviour has been
     # changed by the user by setting PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1
-    return (($ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} || '') eq '1') ? 0 : 1;
+    return (($ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} || '') eq '1') ? 0 : 1;
 }
 
 sub _set_proxies {

--- a/t/180_verify_SSL.t
+++ b/t/180_verify_SSL.t
@@ -7,7 +7,7 @@ use lib 't';
 
 use HTTP::Tiny;
 
-delete $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT};
+delete $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT};
 
 {
     my $ht = HTTP::Tiny->new();
@@ -53,54 +53,54 @@ delete $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT};
 }
 
 {
-    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = "1";
     my $ht = HTTP::Tiny->new();
-    is($ht->verify_SSL, 0, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1 changes verify_SSL default to 0");
+    is($ht->verify_SSL, 0, "PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1 changes verify_SSL default to 0");
 }
 
 {
-    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "0";
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = "0";
     my $ht = HTTP::Tiny->new();
-    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=0 keeps verify_SSL default at 1");
+    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=0 keeps verify_SSL default at 1");
 }
 
 {
-    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "False";
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = "False";
     my $ht = HTTP::Tiny->new();
-    is($ht->verify_SSL, 1, "Unsupported PERL_HTTP_TINY_INSECURE_BY_DEFAULT=False keeps verify_SSL default at 1");
+    is($ht->verify_SSL, 1, "Unsupported PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=False keeps verify_SSL default at 1");
 }
 
 {
-    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = "1";
     my $ht = HTTP::Tiny->new(verify_SSL=>1);
-    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1 does not override verify_SSL attribute set to 1");
+    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1 does not override verify_SSL attribute set to 1");
 }
 
 {
-    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = "1";
     my $ht = HTTP::Tiny->new(
         verify_SSL => 1,
         verify_ssl => 1
     );
-    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1, verify_SSL=>1 and verify_ssl=>1 sets 1");
+    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1, verify_SSL=>1 and verify_ssl=>1 sets 1");
 }
 
 {
-    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = "1";
     my $ht = HTTP::Tiny->new(
         verify_SSL => 1,
         verify_ssl => 0
     );
-    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1, verify_SSL=>1 and verify_ssl=>0 sets 1");
+    is($ht->verify_SSL, 1, "PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1, verify_SSL=>1 and verify_ssl=>0 sets 1");
 }
 
 {
-    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = "1";
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = "1";
     my $ht = HTTP::Tiny->new(
         verify_SSL => 0,
         verify_ssl => 0
     );
-    is($ht->verify_SSL, 0, "PERL_HTTP_TINY_INSECURE_BY_DEFAULT=1, verify_SSL=>0 and verify_ssl=>0 sets 0");
+    is($ht->verify_SSL, 0, "PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1, verify_SSL=>0 and verify_ssl=>0 sets 0");
 }
 
 

--- a/t/210_live_ssl.t
+++ b/t/210_live_ssl.t
@@ -18,7 +18,7 @@ BEGIN {
 }
 use HTTP::Tiny;
 
-delete $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT};
+delete $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT};
 
 plan skip_all => 'Only run for $ENV{AUTOMATED_TESTING}'
   unless $ENV{AUTOMATED_TESTING};
@@ -65,7 +65,7 @@ test_ssl('https://mozilla-modern.badssl.com/' => {
 });
 
 {
-    local $ENV{PERL_HTTP_TINY_INSECURE_BY_DEFAULT} = 1;
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = 1;
     test_ssl('https://wrong.host.badssl.com/' => {
         host => 'wrong.host.badssl.com',
         pass => { verify_SSL => 0 },


### PR DESCRIPTION
The variable to override the verify_SSL default differed slightly in the documentation from what was checked for in the code.

This commit makes the code use `PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT` as documented, instead of `PERL_HTTP_TINY_INSECURE_BY_DEFAULT` which was missing `SSL_`

Cc: @twata1 @noxxi @rjbs